### PR TITLE
Add downloadRules API and rename getUrlVariables API

### DIFF
--- a/src/ACPCoreTestApp.Android/Services/ACPCoreExtensionService.cs
+++ b/src/ACPCoreTestApp.Android/Services/ACPCoreExtensionService.cs
@@ -53,11 +53,19 @@ namespace ACPCoreTestApp.Droid
             return stringOutput;
         }
 
+        public TaskCompletionSource<string> DownloadRules()
+        {
+            // TODO: this method is not implemented on Android
+            stringOutput = new TaskCompletionSource<string>();
+            stringOutput.SetResult("");
+            return stringOutput;
+        }
+
         public TaskCompletionSource<string> GetPrivacyStatus()
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.GetPrivacyStatus(new StringCallback());
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -65,7 +73,7 @@ namespace ACPCoreTestApp.Droid
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.GetSdkIdentities(new StringCallback());
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -73,7 +81,7 @@ namespace ACPCoreTestApp.Droid
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.SetAdvertisingIdentifier("testAdvertisingIdentifier");
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -81,7 +89,7 @@ namespace ACPCoreTestApp.Droid
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.LogLevel = LoggingMode.Verbose;
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -89,7 +97,7 @@ namespace ACPCoreTestApp.Droid
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.SetPrivacyStatus(MobilePrivacyStatus.OptIn);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -99,7 +107,7 @@ namespace ACPCoreTestApp.Droid
             Dictionary<string, string> data = new Dictionary<string, string>();
             data.Add("key", "value");
             ACPCore.TrackAction("action", data);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -109,7 +117,7 @@ namespace ACPCoreTestApp.Droid
             Dictionary<string, string> data = new Dictionary<string, string>();
             data.Add("key", "value");
             ACPCore.TrackState("state", data);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -119,7 +127,7 @@ namespace ACPCoreTestApp.Droid
             Dictionary<string, Java.Lang.Object> config = new Dictionary<string, Java.Lang.Object>();
             config.Add("someConfigKey", "configValue");
             ACPCore.UpdateConfiguration(config);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -155,7 +163,7 @@ namespace ACPCoreTestApp.Droid
             return stringOutput;
         }
 
-        public TaskCompletionSource<string> GetURLVariables()
+        public TaskCompletionSource<string> GetUrlVariables()
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPIdentity.GetUrlVariables(new StringCallback());
@@ -167,8 +175,7 @@ namespace ACPCoreTestApp.Droid
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPIdentity.SyncIdentifier("name", "john", VisitorID.AuthenticationState.Authenticated); 
-            stringOutput.SetResult(" completed");
-
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -180,8 +187,7 @@ namespace ACPCoreTestApp.Droid
             ids.Add("age", "38");
             ids.Add("zipcode", "94403");
             ACPIdentity.SyncIdentifiers(ids);
-            stringOutput.SetResult(" completed");
-
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -193,7 +199,7 @@ namespace ACPCoreTestApp.Droid
             ids.Add("age", "38");
             ids.Add("zipcode", "94403");
             ACPIdentity.SyncIdentifiers(ids, VisitorID.AuthenticationState.LoggedOut);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 

--- a/src/ACPCoreTestApp.iOS/Services/ACPCoreExtensionService.cs
+++ b/src/ACPCoreTestApp.iOS/Services/ACPCoreExtensionService.cs
@@ -75,12 +75,20 @@ namespace ACPCoreTestApp.iOS
             return stringOutput;
         }
 
+        public TaskCompletionSource<string> DownloadRules()
+        {
+            stringOutput = new TaskCompletionSource<string>();
+            ACPCore.DownloadRules();
+            stringOutput.SetResult("completed");
+            return stringOutput;
+        }
+
         public TaskCompletionSource<string> GetPrivacyStatus()
         {
             stringOutput = new TaskCompletionSource<string>();
             Action<ACPMobilePrivacyStatus> callback = new Action<ACPMobilePrivacyStatus>(handleCallback);
             ACPCore.GetPrivacyStatus(callback);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -89,7 +97,7 @@ namespace ACPCoreTestApp.iOS
             stringOutput = new TaskCompletionSource<string>();
             Action<NSString> callback = new Action<NSString>(handleCallback);
             ACPCore.GetSdkIdentities(callback);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -97,7 +105,7 @@ namespace ACPCoreTestApp.iOS
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.SetAdvertisingIdentifier("testAdvertisingIdentifier");
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -105,7 +113,7 @@ namespace ACPCoreTestApp.iOS
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.LogLevel = ACPMobileLogLevel.Verbose;
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -113,7 +121,7 @@ namespace ACPCoreTestApp.iOS
         {
             stringOutput = new TaskCompletionSource<string>();
             ACPCore.SetPrivacyStatus(ACPMobilePrivacyStatus.OptIn);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -125,7 +133,7 @@ namespace ACPCoreTestApp.iOS
                 ["key"] = new NSString("value")
             };
             ACPCore.TrackAction("action", data);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -137,7 +145,7 @@ namespace ACPCoreTestApp.iOS
                 ["key"] = new NSString("value")
             };
             ACPCore.TrackState("state", data);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -149,7 +157,7 @@ namespace ACPCoreTestApp.iOS
                 ["someConfigKey"] = new NSString("configValue")
             };
             ACPCore.UpdateConfiguration(config);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -189,7 +197,7 @@ namespace ACPCoreTestApp.iOS
             return stringOutput;
         }
 
-        public TaskCompletionSource<string> GetURLVariables()
+        public TaskCompletionSource<string> GetUrlVariables()
         {
             stringOutput = new TaskCompletionSource<string>();
             Action<NSString> callback = new Action<NSString> (handleCallback);
@@ -203,8 +211,7 @@ namespace ACPCoreTestApp.iOS
             stringOutput = new TaskCompletionSource<string>();
             Action<NSString> callback = new Action<NSString>(handleCallback);
             ACPIdentity.SyncIdentifier("name", "john", ACPMobileVisitorAuthenticationState.Authenticated);
-            stringOutput.SetResult(" completed");
-
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -218,8 +225,7 @@ namespace ACPCoreTestApp.iOS
                 ["zipcode"] = new NSString("94403")
             };
             ACPIdentity.SyncIdentifiers(ids);
-            stringOutput.SetResult(" completed");
-
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 
@@ -233,7 +239,7 @@ namespace ACPCoreTestApp.iOS
                 ["zipcode"] = new NSString("94403")
             };
             ACPIdentity.SyncIdentifiers(ids, ACPMobileVisitorAuthenticationState.LoggedOut);
-            stringOutput.SetResult(" completed");
+            stringOutput.SetResult("completed");
             return stringOutput;
         }
 

--- a/src/ACPCoreTestApp/MainPage.xaml
+++ b/src/ACPCoreTestApp/MainPage.xaml
@@ -8,6 +8,7 @@
                 <Button Text="Dispatch Event" BackgroundColor="LightGray" Clicked="OnDispatchEventButtonClicked"/>
                 <Button Text="Dispatch Event With Response Callback" BackgroundColor="LightGray" Clicked="OnDispatchEventWithResponseCallbackButtonClicked"/>
                 <Button Text="Dispatch Response Event" BackgroundColor="LightGray" Clicked="OnDispatchResponseEventButtonClicked"/>
+                <Button Text="Download Rules" BackgroundColor="LightGray" Clicked="OnDownloadRulesButtonClicked"/>
                 <Button Text="Get Privacy Status" BackgroundColor="LightGray" Clicked="OnGetPrivacyStatusButtonClicked"/>
                 <Button Text="Get SDK Identities" BackgroundColor="LightGray" Clicked="OnGetSDKIdentitiesButtonClicked"/>
                 <Button Text="Set Advertising Identifier" BackgroundColor="LightGray" Clicked="OnSetAdvertisingIdentifierButtonClicked"/>

--- a/src/ACPCoreTestApp/MainPage.xaml.cs
+++ b/src/ACPCoreTestApp/MainPage.xaml.cs
@@ -43,6 +43,12 @@ namespace ACPCoreTestApp
 
         }
 
+        void OnDownloadRulesButtonClicked(object sender, EventArgs args)
+        {
+            string result = DependencyService.Get<IACPCoreExtensionService>().DownloadRules().Task.Result;
+            handleStringResult("DownloadRules", result);
+        }
+
         void OnGetPrivacyStatusButtonClicked(object sender, EventArgs args)
         {
             string result = DependencyService.Get<IACPCoreExtensionService>().GetPrivacyStatus().Task.Result;
@@ -118,8 +124,8 @@ namespace ACPCoreTestApp
 
         void OnGetURLVariablesButtonClicked(object sender, EventArgs args)
         {
-            string result = DependencyService.Get<IACPCoreExtensionService>().GetURLVariables().Task.Result;
-            handleStringResult("GetURLVariables", result);
+            string result = DependencyService.Get<IACPCoreExtensionService>().GetUrlVariables().Task.Result;
+            handleStringResult("GetUrlVariables", result);
         }
 
         void OnSyncIdentifierButtonClicked(object sender, EventArgs args)

--- a/src/ACPCoreTestApp/Services/IACPCoreExtensionService.cs
+++ b/src/ACPCoreTestApp/Services/IACPCoreExtensionService.cs
@@ -10,6 +10,7 @@ namespace ACPCoreTestApp
         TaskCompletionSource<string> DispatchEvent();
         TaskCompletionSource<string> DispatchEventWithResponseCallback();
         TaskCompletionSource<string> DispatchResponseEvent();
+        TaskCompletionSource<string> DownloadRules();
         TaskCompletionSource<string> GetPrivacyStatus();
         TaskCompletionSource<string> GetSDKIdentities();
         TaskCompletionSource<string> SetAdvertisingIdentifier();
@@ -23,7 +24,7 @@ namespace ACPCoreTestApp
         TaskCompletionSource<string> AppendVisitorInfoForUrl();
         TaskCompletionSource<string> GetExperienceCloudId();
         TaskCompletionSource<string> GetIdentifiers();
-        TaskCompletionSource<string> GetURLVariables();
+        TaskCompletionSource<string> GetUrlVariables();
         TaskCompletionSource<string> SyncIdentifier();
         TaskCompletionSource<string> SyncIdentifiers();
         TaskCompletionSource<string> SyncIdentifiersWithAuthState();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I had missed adding the downloadRules API to the wrapper. It is available for iOS only and does nothing if called on the android side. I have also renamed getURLVariables to getUrlVariables to match the original api name.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
